### PR TITLE
Add simple Flask front-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-Hi
+# Apartment Tracker
+
+This project fetches apartment listings from Boliga.dk and saves them to
+`listings.json`. A small Flask web app is included so you can view the
+latest listings in your browser.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the web front-end
+
+Start the server with:
+
+```bash
+python frontend.py
+```
+
+Visit [http://localhost:8000](http://localhost:8000) to see the saved
+listings. Use `/refresh` in your browser to fetch the latest data.

--- a/frontend.py
+++ b/frontend.py
@@ -1,0 +1,47 @@
+from flask import Flask, render_template_string
+
+from check_listings import (
+    scrape_listings,
+    load_previous_listings,
+    save_listings,
+)
+
+app = Flask(__name__)
+
+TEMPLATE = """
+<!doctype html>
+<title>Apartment Tracker</title>
+<h1>Latest Listings</h1>
+{% if listings %}
+<ul>
+{% for item in listings %}
+    <li>
+        <a href="{{ item.url }}">{{ item.address }}</a> |
+        Price: {{ item.price }} |
+        Size: {{ item.size }} m²
+    </li>
+{% endfor %}
+</ul>
+{% else %}
+<p>No listings found.</p>
+{% endif %}
+"""
+
+@app.route("/")
+def index():
+    listings = load_previous_listings()
+    if not listings:
+        listings = scrape_listings()
+        if listings:
+            save_listings(listings)
+    return render_template_string(TEMPLATE, listings=listings)
+
+@app.route("/refresh")
+def refresh():
+    listings = scrape_listings()
+    if listings:
+        save_listings(listings)
+    return render_template_string(TEMPLATE, listings=listings)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests


### PR DESCRIPTION
## Summary
- add small Flask web server for scraping results
- document how to start the server
- declare Flask and requests as dependencies

## Testing
- `python -m py_compile check_listings.py frontend.py`
- `python check_listings.py` *(fails: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684695bac07c833081b9b90f5fbd9deb