### PR TITLE
Create mobile-ready Rover Explorer prototype

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,113 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Game Prototype</title>
+    <title>Rover Explorer</title>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <main class="viewport">
-      <section class="hud">
-        <h1>Interactive Web Game Prototype</h1>
-        <p class="tagline">Hello, world! The adventure will begin here soon.</p>
+    <header class="app-header">
+      <h1>Rover Explorer</h1>
+      <p class="subtitle">Design the mission, configure the rover, and scout a living world from your phone.</p>
+    </header>
+
+    <main class="layout">
+      <section class="panel" aria-labelledby="world-config-title">
+        <h2 id="world-config-title">World Configuration</h2>
+        <p class="panel-intro">
+          Tune the geological age and climate sliders to influence the planet that will be generated for this expedition.
+        </p>
+        <div class="form-field">
+          <label for="ageSlider">Geological Age <span class="value" id="ageValue">50</span></label>
+          <input type="range" id="ageSlider" min="0" max="100" value="50" />
+          <p class="hint">Young worlds are jagged and volatile. Older worlds are smoother and eroded.</p>
+        </div>
+        <div class="form-field">
+          <label for="temperatureSlider">Temperature <span class="value" id="temperatureValue">50</span></label>
+          <input type="range" id="temperatureSlider" min="0" max="100" value="50" />
+          <p class="hint">Lower values trend toward frozen tundras. Higher values generate deserts and jungles.</p>
+        </div>
+        <div class="form-field">
+          <label for="humiditySlider">Humidity <span class="value" id="humidityValue">50</span></label>
+          <input type="range" id="humiditySlider" min="0" max="100" value="50" />
+          <p class="hint">Dry climates expose minerals while humid climates grow dense vegetation.</p>
+        </div>
       </section>
-      <canvas id="gameCanvas" width="640" height="360" aria-label="Game canvas"></canvas>
+
+      <section class="panel" aria-labelledby="rover-config-title">
+        <h2 id="rover-config-title">Rover Configuration</h2>
+        <p class="panel-intro">Select modules that complement the mission's conditions.</p>
+        <div class="form-field">
+          <label for="locomotionSelect">Locomotion</label>
+          <select id="locomotionSelect"></select>
+          <p class="hint" id="locomotionHint"></p>
+        </div>
+        <div class="form-field">
+          <label for="powerSelect">Power Core</label>
+          <select id="powerSelect"></select>
+          <p class="hint" id="powerHint"></p>
+        </div>
+        <div class="form-field">
+          <label for="cargoSelect">Cargo Hold</label>
+          <select id="cargoSelect"></select>
+          <p class="hint" id="cargoHint"></p>
+        </div>
+        <div class="form-field">
+          <label for="utilitySelect">Utility Module</label>
+          <select id="utilitySelect"></select>
+          <p class="hint" id="utilityHint"></p>
+        </div>
+        <button id="launchButton" class="primary" type="button">Launch Expedition</button>
+      </section>
+
+      <section class="panel expedition" aria-live="polite" aria-labelledby="expedition-title">
+        <div class="expedition-header">
+          <h2 id="expedition-title">Expedition Status</h2>
+          <button id="endButton" class="ghost" type="button">End Expedition</button>
+        </div>
+        <div class="mission-stats">
+          <div class="stat">
+            <span class="label">Energy</span>
+            <span id="energyStat" class="value">0</span>
+          </div>
+          <div class="stat">
+            <span class="label">Cargo</span>
+            <span id="cargoStat" class="value">0 / 0</span>
+          </div>
+          <div class="stat">
+            <span class="label">Resources</span>
+            <span id="resourcesStat" class="value">0</span>
+          </div>
+          <div class="stat">
+            <span class="label">Exploration</span>
+            <span id="explorationStat" class="value">0</span>
+          </div>
+        </div>
+        <div class="map-wrapper">
+          <div class="map" id="map" role="grid" aria-label="Exploration map"></div>
+          <aside class="map-sidebar">
+            <h3>Terrain Summary</h3>
+            <ul id="legend" class="legend"></ul>
+          </aside>
+        </div>
+        <div class="controls" aria-label="Rover controls">
+          <div class="dpad">
+            <button data-direction="up" aria-label="Move north">▲</button>
+            <div class="middle-row">
+              <button data-direction="left" aria-label="Move west">◄</button>
+              <button data-direction="scan" aria-label="Scan surroundings">◎</button>
+              <button data-direction="right" aria-label="Move east">►</button>
+            </div>
+            <button data-direction="down" aria-label="Move south">▼</button>
+          </div>
+          <button id="collectButton" class="primary" type="button">Collect Resource</button>
+        </div>
+        <p class="status-message" id="statusMessage">Configure a mission and launch to begin your expedition.</p>
+      </section>
     </main>
+
+    <footer class="app-footer">
+      <p>Prototype inspired by the Rover Explorer design document. Optimized for touch screens and mobile browsers.</p>
+    </footer>
 
     <script type="module" src="main.js"></script>
   </body>

--- a/main.js
+++ b/main.js
@@ -1,41 +1,624 @@
-const canvas = document.getElementById("gameCanvas");
-const context = canvas.getContext("2d");
+const GRID_SIZE = 10;
+const BASE_MOVE_COST = 4;
+const BASE_VISION = 1;
 
-function resizeCanvas() {
-  const scale = window.devicePixelRatio || 1;
-  const { width, height } = canvas;
-  canvas.width = width * scale;
-  canvas.height = height * scale;
-  canvas.style.width = `${width}px`;
-  canvas.style.height = `${height}px`;
-  context.scale(scale, scale);
+const BIOME_LABELS = {
+  plain: "Plain",
+  mountain: "Ridge",
+  desert: "Dune",
+  jungle: "Jungle",
+  tundra: "Tundra",
+  swamp: "Swamp",
+  lava: "Lava",
+  ocean: "Ocean",
+  river: "River"
+};
+
+const RESOURCE_VALUES = {
+  none: 0,
+  iron: 12,
+  crystal: 18,
+  bio: 9
+};
+
+const locomotionModules = [
+  {
+    id: "wheels",
+    name: "All-Terrain Wheels",
+    description: "Balanced movers. Efficient on plains and dunes but slowed in deep jungle and swamps.",
+    baseMultiplier: 1,
+    modifiers: {
+      jungle: 1.2,
+      swamp: 1.25,
+      mountain: 1.3,
+      lava: 2.2,
+      ocean: Infinity
+    }
+  },
+  {
+    id: "treads",
+    name: "Larva Treads",
+    description: "Heavy treads shrug off rough or icy ground at the cost of higher baseline energy use.",
+    baseMultiplier: 1.2,
+    modifiers: {
+      mountain: 0.85,
+      tundra: 0.85,
+      jungle: 0.95,
+      lava: 1.5,
+      ocean: Infinity
+    }
+  },
+  {
+    id: "skimmer",
+    name: "Hydro Skimmer",
+    description: "Hovercraft that glides over water and wetlands. Struggles in steep or rocky terrain.",
+    baseMultiplier: 1.15,
+    modifiers: {
+      swamp: 0.7,
+      ocean: 0.65,
+      river: 0.65,
+      mountain: 1.8,
+      lava: Infinity
+    }
+  }
+];
+
+const powerModules = [
+  {
+    id: "compact",
+    name: "Compact Core",
+    description: "Reliable power pack suited for short sorties.",
+    energy: 52
+  },
+  {
+    id: "expansion",
+    name: "Expansion Cells",
+    description: "Additional battery racks that extend the mission clock.",
+    energy: 70
+  },
+  {
+    id: "fusion",
+    name: "Fusion Capsule",
+    description: "Prototype power plant enabling long-range expeditions.",
+    energy: 88
+  }
+];
+
+const cargoModules = [
+  {
+    id: "satchel",
+    name: "Survey Satchel",
+    description: "Lightweight container that fits a handful of samples.",
+    capacity: 5
+  },
+  {
+    id: "bay",
+    name: "Modular Cargo Bay",
+    description: "Balanced hold for extended runs without overburdening the rover.",
+    capacity: 8
+  },
+  {
+    id: "vault",
+    name: "Cryo Vault",
+    description: "Cryogenic vault for delicate resources. Heavy but cavernous.",
+    capacity: 11
+  }
+];
+
+const utilityModules = [
+  {
+    id: "none",
+    name: "Basic Optics",
+    description: "Standard sensors with limited range.",
+    visionBonus: 0,
+    scanRange: 0,
+    scanCost: 0,
+    resourceBonus: 0
+  },
+  {
+    id: "scanner",
+    name: "Survey Scanner",
+    description: "Reveal a larger area and ping nearby terrain using focused scans.",
+    visionBonus: 1,
+    scanRange: 2,
+    scanCost: 6,
+    resourceBonus: 0
+  },
+  {
+    id: "excavator",
+    name: "Excavation Arm",
+    description: "Automated sampling arm that extracts cleaner yields from deposits.",
+    visionBonus: 0,
+    scanRange: 1,
+    scanCost: 5,
+    resourceBonus: 3
+  }
+];
+
+const tileDifficulty = {
+  plain: 1,
+  desert: 1.15,
+  jungle: 1.4,
+  tundra: 1.35,
+  swamp: 1.45,
+  mountain: 1.75,
+  lava: 2.2,
+  ocean: 1.5,
+  river: 1.25
+};
+
+const sliders = [
+  { input: document.getElementById("ageSlider"), value: document.getElementById("ageValue") },
+  { input: document.getElementById("temperatureSlider"), value: document.getElementById("temperatureValue") },
+  { input: document.getElementById("humiditySlider"), value: document.getElementById("humidityValue") }
+];
+
+const selects = {
+  locomotion: document.getElementById("locomotionSelect"),
+  power: document.getElementById("powerSelect"),
+  cargo: document.getElementById("cargoSelect"),
+  utility: document.getElementById("utilitySelect")
+};
+
+const hints = {
+  locomotion: document.getElementById("locomotionHint"),
+  power: document.getElementById("powerHint"),
+  cargo: document.getElementById("cargoHint"),
+  utility: document.getElementById("utilityHint")
+};
+
+const mapElement = document.getElementById("map");
+const legendElement = document.getElementById("legend");
+const launchButton = document.getElementById("launchButton");
+const collectButton = document.getElementById("collectButton");
+const statusMessage = document.getElementById("statusMessage");
+const endButton = document.getElementById("endButton");
+const controlButtons = Array.from(document.querySelectorAll(".dpad button"));
+
+const energyStat = document.getElementById("energyStat");
+const cargoStat = document.getElementById("cargoStat");
+const resourcesStat = document.getElementById("resourcesStat");
+const explorationStat = document.getElementById("explorationStat");
+
+const state = {
+  grid: [],
+  tiles: [],
+  running: false,
+  position: { x: 0, y: 0 },
+  energy: 0,
+  maxEnergy: 0,
+  cargo: 0,
+  cargoCapacity: 0,
+  resources: 0,
+  exploration: 0,
+  modules: {
+    locomotion: locomotionModules[0],
+    power: powerModules[0],
+    cargo: cargoModules[0],
+    utility: utilityModules[0]
+  },
+  world: {
+    age: 50,
+    temperature: 50,
+    humidity: 50,
+    legend: new Map()
+  }
+};
+
+function initialise() {
+  sliders.forEach(({ input, value }) => {
+    value.textContent = input.value;
+    input.addEventListener("input", () => {
+      value.textContent = input.value;
+    });
+  });
+
+  populateSelect(selects.locomotion, locomotionModules, module => module.name, module => module.description);
+  populateSelect(selects.power, powerModules, module => module.name, module => module.description);
+  populateSelect(selects.cargo, cargoModules, module => module.name, module => module.description);
+  populateSelect(selects.utility, utilityModules, module => module.name, module => module.description);
+
+  launchButton.addEventListener("click", launchExpedition);
+  collectButton.addEventListener("click", collectResource);
+  endButton.addEventListener("click", endExpedition);
+
+  controlButtons.forEach(button => {
+    button.addEventListener("click", () => {
+      const direction = button.dataset.direction;
+      if (direction === "scan") {
+        performScan();
+      } else {
+        moveRover(direction);
+      }
+    });
+  });
+
+  updateUIStates(false);
+  updateStats();
 }
 
-function drawGreeting() {
-  const gradient = context.createLinearGradient(0, 0, canvas.width, canvas.height);
-  gradient.addColorStop(0, "#8a9bff");
-  gradient.addColorStop(1, "#5d7cff");
+function populateSelect(selectElement, modules, labelGetter, descriptionGetter) {
+  selectElement.innerHTML = "";
+  modules.forEach(module => {
+    const option = document.createElement("option");
+    option.value = module.id;
+    option.textContent = labelGetter(module);
+    selectElement.append(option);
+  });
 
-  context.clearRect(0, 0, canvas.width, canvas.height);
-  context.fillStyle = "rgba(10, 14, 24, 0.85)";
-  context.fillRect(0, 0, canvas.width, canvas.height);
+  selectElement.value = modules[0].id;
+  hints[selectElement.id.replace("Select", "")].textContent = descriptionGetter(modules[0]);
 
-  context.fillStyle = gradient;
-  context.font = "bold 48px 'Segoe UI', Tahoma, sans-serif";
-  context.textAlign = "center";
-  context.textBaseline = "middle";
-  context.fillText("Hello, world!", canvas.width / 2, canvas.height / 2 - 20);
+  selectElement.addEventListener("change", () => {
+    const selectedModule = modules.find(module => module.id === selectElement.value);
+    const hintKey = selectElement.id.replace("Select", "");
+    hints[hintKey].textContent = descriptionGetter(selectedModule);
+    state.modules[hintKey] = selectedModule;
+  });
 
-  context.font = "24px 'Segoe UI', Tahoma, sans-serif";
-  context.fillStyle = "rgba(240, 243, 255, 0.9)";
-  context.fillText("Your interactive adventure starts here.", canvas.width / 2, canvas.height / 2 + 28);
+  state.modules[selectElement.id.replace("Select", "")] = modules[0];
 }
 
-resizeCanvas();
-drawGreeting();
+function launchExpedition() {
+  const age = Number(selectors.ageSlider.value);
+  const temperature = Number(selectors.temperatureSlider.value);
+  const humidity = Number(selectors.humiditySlider.value);
 
-window.addEventListener("resize", () => {
-  context.setTransform(1, 0, 0, 1, 0, 0);
-  resizeCanvas();
-  drawGreeting();
-});
+  state.world = { age, temperature, humidity, legend: new Map() };
+
+  state.modules.locomotion = locomotionModules.find(module => module.id === selects.locomotion.value);
+  state.modules.power = powerModules.find(module => module.id === selects.power.value);
+  state.modules.cargo = cargoModules.find(module => module.id === selects.cargo.value);
+  state.modules.utility = utilityModules.find(module => module.id === selects.utility.value);
+
+  state.energy = state.modules.power.energy;
+  state.maxEnergy = state.modules.power.energy;
+  state.cargo = 0;
+  state.cargoCapacity = state.modules.cargo.capacity;
+  state.resources = 0;
+  state.exploration = 0;
+  state.running = true;
+
+  const generation = generateWorld(age, temperature, humidity);
+  state.grid = generation.grid;
+  state.tiles = generation.tiles;
+  state.world.legend = generation.legend;
+  state.position = { x: Math.floor(GRID_SIZE / 2), y: Math.floor(GRID_SIZE / 2) };
+
+  renderLegend(state.world.legend);
+  buildMap();
+  revealArea(state.position.x, state.position.y, BASE_VISION + state.modules.utility.visionBonus);
+  updateStats();
+  updateUIStates(true);
+  setStatus("Expedition launched. Chart the unknown and recover resources.");
+}
+
+const selectors = {
+  get ageSlider() {
+    return document.getElementById("ageSlider");
+  },
+  get temperatureSlider() {
+    return document.getElementById("temperatureSlider");
+  },
+  get humiditySlider() {
+    return document.getElementById("humiditySlider");
+  }
+};
+
+function generateWorld(age, temperature, humidity) {
+  const grid = [];
+  const tiles = [];
+  const legend = new Map();
+  const seed = Math.floor(Date.now() + age * 31 + temperature * 97 + humidity * 131);
+
+  for (let y = 0; y < GRID_SIZE; y += 1) {
+    const row = [];
+    for (let x = 0; x < GRID_SIZE; x += 1) {
+      const tile = createTile(x, y, age, temperature, humidity, seed);
+      row.push(tile);
+      tiles.push(tile);
+      legend.set(tile.biome, (legend.get(tile.biome) ?? 0) + 1);
+    }
+    grid.push(row);
+  }
+
+  return { grid, tiles, legend };
+}
+
+function createTile(x, y, age, temperature, humidity, seed) {
+  const ageNorm = age / 100;
+  const tempNorm = temperature / 100;
+  const humidityNorm = humidity / 100;
+  const reliefScale = 1.2 + (1 - ageNorm) * 1.3;
+  const elevationNoise = layeredNoise(x, y, reliefScale, seed);
+  const moistureNoise = layeredNoise(x + 13, y + 7, 1.4, seed * 0.7 + 113);
+  const tempNoise = layeredNoise(x + 3, y + 19, 0.9, seed * 1.1 + 37);
+
+  const elevation = Math.pow(elevationNoise, 0.65 + ageNorm * 0.8);
+  const moisture = Math.min(1, humidityNorm * 0.55 + moistureNoise * 0.7);
+  const tempValue = Math.min(1, tempNorm * 0.5 + tempNoise * 0.7);
+
+  let biome = "plain";
+
+  if (elevation < 0.18) {
+    biome = humidityNorm > 0.5 ? "river" : "ocean";
+  } else if (elevation > 0.82 && tempValue > 0.6 && ageNorm < 0.4) {
+    biome = "lava";
+  } else if (elevation > 0.72) {
+    biome = "mountain";
+  } else if (moisture > 0.7 && tempValue > 0.6) {
+    biome = "jungle";
+  } else if (moisture > 0.68) {
+    biome = "swamp";
+  } else if (tempValue < 0.28) {
+    biome = "tundra";
+  } else if (moisture < 0.28 && tempValue > 0.55) {
+    biome = "desert";
+  } else {
+    biome = "plain";
+  }
+
+  const resource = determineResource(biome, moisture, elevation, tempValue, seed, x, y);
+
+  return {
+    x,
+    y,
+    biome,
+    resource,
+    discovered: false,
+    element: null
+  };
+}
+
+function layeredNoise(x, y, scale, seed) {
+  const nx = (x / GRID_SIZE) * scale;
+  const ny = (y / GRID_SIZE) * scale;
+  const a = noise(nx, ny, seed);
+  const b = noise(nx * 2.7, ny * 2.7, seed + 71) * 0.5;
+  const c = noise(nx * 5.1, ny * 5.1, seed + 143) * 0.25;
+  return Math.min(1, Math.max(0, (a + b + c) / 1.75));
+}
+
+function noise(x, y, seed) {
+  const s = Math.sin(x * 127.1 + y * 311.7 + seed * 0.01) * 43758.5453;
+  return s - Math.floor(s);
+}
+
+function determineResource(biome, moisture, elevation, tempValue, seed, x, y) {
+  const chanceNoise = noise(x + 11.3, y + 17.9, seed + 311);
+  if (biome === "mountain" && chanceNoise > 0.68) {
+    return "crystal";
+  }
+  if (biome === "lava" && chanceNoise > 0.54) {
+    return "crystal";
+  }
+  if ((biome === "river" || biome === "ocean") && chanceNoise > 0.76) {
+    return "bio";
+  }
+  if (biome === "jungle" && chanceNoise > 0.6) {
+    return "bio";
+  }
+  if (biome === "plain" && chanceNoise > 0.7) {
+    return moisture < 0.45 ? "iron" : "bio";
+  }
+  if (biome === "desert" && chanceNoise > 0.64) {
+    return "iron";
+  }
+  if (biome === "tundra" && chanceNoise > 0.66) {
+    return "iron";
+  }
+  return "none";
+}
+
+function buildMap() {
+  mapElement.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  state.grid.forEach(row => {
+    row.forEach(tile => {
+      const tileElement = document.createElement("div");
+      tileElement.className = "tile";
+      tileElement.dataset.state = "hidden";
+      tileElement.dataset.biome = tile.biome;
+      tileElement.dataset.resource = "none";
+      tileElement.textContent = "";
+      tile.element = tileElement;
+      tileElement.addEventListener("click", () => handleTileTap(tile));
+      fragment.append(tileElement);
+    });
+  });
+  mapElement.append(fragment);
+}
+
+function handleTileTap(tile) {
+  if (!state.running) return;
+  const dx = tile.x - state.position.x;
+  const dy = tile.y - state.position.y;
+  const isAdjacent = Math.abs(dx) + Math.abs(dy) === 1;
+  if (isAdjacent) {
+    moveRover(dx === 1 ? "right" : dx === -1 ? "left" : dy === 1 ? "down" : "up");
+  }
+}
+
+function revealArea(cx, cy, radius) {
+  for (let y = cy - radius; y <= cy + radius; y += 1) {
+    for (let x = cx - radius; x <= cx + radius; x += 1) {
+      if (x < 0 || y < 0 || x >= GRID_SIZE || y >= GRID_SIZE) continue;
+      revealTile(x, y);
+    }
+  }
+  updateTileStates();
+}
+
+function revealTile(x, y) {
+  const tile = state.grid[y][x];
+  if (!tile.discovered) {
+    tile.discovered = true;
+    state.exploration += 1;
+  }
+  tile.element.dataset.state = "revealed";
+  tile.element.textContent = BIOME_LABELS[tile.biome];
+}
+
+function updateTileStates() {
+  state.grid.forEach(row => {
+    row.forEach(tile => {
+      if (!tile.discovered) {
+        tile.element.dataset.state = "hidden";
+        tile.element.textContent = "";
+        tile.element.dataset.resource = "none";
+      } else {
+        tile.element.textContent = BIOME_LABELS[tile.biome];
+        tile.element.dataset.state = tile === getCurrentTile() ? "current" : "revealed";
+        tile.element.dataset.resource = tile.resource;
+      }
+    });
+  });
+}
+
+function getCurrentTile() {
+  return state.grid[state.position.y][state.position.x];
+}
+
+function moveRover(direction) {
+  if (!state.running) return;
+  const deltas = {
+    up: { dx: 0, dy: -1 },
+    down: { dx: 0, dy: 1 },
+    left: { dx: -1, dy: 0 },
+    right: { dx: 1, dy: 0 }
+  };
+
+  const delta = deltas[direction];
+  if (!delta) return;
+
+  const targetX = state.position.x + delta.dx;
+  const targetY = state.position.y + delta.dy;
+
+  if (targetX < 0 || targetY < 0 || targetX >= GRID_SIZE || targetY >= GRID_SIZE) {
+    setStatus("The rover's navigation suite warns of sheer cliffs. Choose another path.");
+    return;
+  }
+
+  const targetTile = state.grid[targetY][targetX];
+  const cost = calculateMovementCost(targetTile);
+  if (!Number.isFinite(cost)) {
+    setStatus("The rover cannot traverse that terrain with the current locomotion module.");
+    return;
+  }
+
+  if (state.energy < cost) {
+    setStatus("Insufficient energy reserves for that maneuver.");
+    return;
+  }
+
+  state.energy -= cost;
+  state.position = { x: targetX, y: targetY };
+  revealArea(targetX, targetY, BASE_VISION + state.modules.utility.visionBonus);
+  updateTileStates();
+  updateStats();
+  describeTile(targetTile);
+
+  if (state.energy <= 0) {
+    setStatus("Energy depleted. The expedition must return home.");
+    endExpedition();
+  }
+}
+
+function calculateMovementCost(tile) {
+  const locomotion = state.modules.locomotion;
+  const biomeModifier = locomotion.modifiers[tile.biome] ?? 1;
+  const difficulty = tileDifficulty[tile.biome] ?? 1.1;
+  return Math.ceil(BASE_MOVE_COST * difficulty * locomotion.baseMultiplier * biomeModifier);
+}
+
+function describeTile(tile) {
+  if (tile.resource !== "none") {
+    const resourceNames = {
+      iron: "rich ferric deposits",
+      crystal: "rare crystalline formations",
+      bio: "bioluminescent flora"
+    };
+    setStatus(`Sensors highlight ${resourceNames[tile.resource]} in the ${BIOME_LABELS[tile.biome].toLowerCase()}.`);
+  } else {
+    setStatus(`Exploring ${BIOME_LABELS[tile.biome].toLowerCase()} terrain.`);
+  }
+}
+
+function performScan() {
+  if (!state.running) return;
+  const { scanRange, scanCost } = state.modules.utility;
+  if (scanRange <= 0) {
+    setStatus("No advanced scanners installed. Upgrade the utility slot to perform scans.");
+    return;
+  }
+  if (state.energy < scanCost) {
+    setStatus("Scanning aborted. Energy reserves too low.");
+    return;
+  }
+  state.energy -= scanCost;
+  revealArea(state.position.x, state.position.y, scanRange + BASE_VISION);
+  updateStats();
+  setStatus("Survey scan complete. Nearby tiles charted.");
+}
+
+function collectResource() {
+  if (!state.running) return;
+  const tile = getCurrentTile();
+  if (tile.resource === "none") {
+    setStatus("No recoverable resources detected on this tile.");
+    return;
+  }
+  if (state.cargo >= state.cargoCapacity) {
+    setStatus("Cargo hold is full. Return to base to offload samples.");
+    return;
+  }
+
+  state.cargo += 1;
+  const value = RESOURCE_VALUES[tile.resource] + state.modules.utility.resourceBonus;
+  state.resources += value;
+  setStatus(`Sample secured. Cargo usage: ${state.cargo}/${state.cargoCapacity}.`);
+  tile.resource = "none";
+  updateTileStates();
+  updateStats();
+}
+
+function updateStats() {
+  energyStat.textContent = `${state.energy} / ${state.maxEnergy}`;
+  cargoStat.textContent = `${state.cargo} / ${state.cargoCapacity}`;
+  resourcesStat.textContent = `${state.resources}`;
+  explorationStat.textContent = `${state.exploration}`;
+}
+
+function setStatus(message) {
+  statusMessage.textContent = message;
+}
+
+function renderLegend(legend) {
+  legendElement.innerHTML = "";
+  const entries = Array.from(legend.entries()).sort((a, b) => b[1] - a[1]);
+  entries.forEach(([biome, count]) => {
+    const item = document.createElement("li");
+    item.textContent = `${BIOME_LABELS[biome] ?? biome}: ${count}`;
+    legendElement.append(item);
+  });
+}
+
+function endExpedition() {
+  if (!state.running) {
+    return;
+  }
+  state.running = false;
+  updateUIStates(false);
+  setStatus(`Mission concluded. Recovered resources valued at ${state.resources} units.`);
+}
+
+function updateUIStates(isRunning) {
+  controlButtons.forEach(button => {
+    button.disabled = !isRunning;
+  });
+  collectButton.disabled = !isRunning;
+  endButton.disabled = !isRunning;
+  launchButton.disabled = false;
+}
+
+initialise();

--- a/style.css
+++ b/style.css
@@ -1,48 +1,384 @@
 :root {
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  font-family: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   color-scheme: dark;
-  background-color: #0d0f14;
-  color: #f0f3ff;
+  --bg: #06070b;
+  --surface: rgba(18, 21, 32, 0.85);
+  --surface-strong: rgba(30, 36, 52, 0.92);
+  --accent: #7da6ff;
+  --accent-strong: #9cc4ff;
+  --text: #f4f6ff;
+  --muted: #97a1c1;
+  background: radial-gradient(circle at 20% 20%, rgba(47, 61, 96, 0.45), transparent 60%),
+    radial-gradient(circle at 80% 0%, rgba(37, 45, 71, 0.55), transparent 60%),
+    var(--bg);
+  color: var(--text);
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
   display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: clamp(1rem, 2.5vw, 2rem);
+}
+
+.app-header,
+.app-footer {
+  text-align: center;
+  padding-inline: clamp(0.5rem, 3vw, 2rem);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+  letter-spacing: 0.04em;
+}
+
+.subtitle {
+  margin: 0.5rem auto 0;
+  max-width: 52ch;
+  color: var(--muted);
+  font-size: clamp(1rem, 3.2vw, 1.2rem);
+}
+
+.app-footer {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.layout {
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.75rem);
+  width: min(1080px, 100%);
+  margin: 0 auto;
+}
+
+@media (min-width: 960px) {
+  .layout {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    align-items: start;
+  }
+
+  .layout .expedition {
+    grid-column: 1 / -1;
+  }
+}
+
+.panel {
+  background: var(--surface);
+  border-radius: 20px;
+  padding: clamp(1rem, 3vw, 1.75rem);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 18px 40px rgba(5, 7, 15, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: clamp(1.35rem, 3vw, 1.75rem);
+}
+
+.panel-intro {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-field label {
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.form-field input[type="range"],
+.form-field select {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+.form-field select {
+  background: rgba(15, 18, 28, 0.8);
+  color: var(--text);
+  border: 1px solid rgba(125, 166, 255, 0.35);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+}
+
+.form-field input[type="range"] {
+  height: 2.25rem;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+button {
+  font: inherit;
+  border: none;
+  border-radius: 14px;
+  padding: 0.7rem 1.2rem;
+  cursor: pointer;
+  background: rgba(125, 166, 255, 0.15);
+  color: var(--accent-strong);
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+button:active {
+  transform: translateY(1px) scale(0.99);
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(125, 166, 255, 0.65);
+  outline-offset: 2px;
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--accent), #5479ff);
+  color: #05070c;
+  font-weight: 700;
+  box-shadow: 0 12px 22px rgba(77, 129, 255, 0.35);
+}
+
+button.primary:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button.ghost {
+  align-self: flex-start;
+  background: transparent;
+  border: 1px solid rgba(125, 166, 255, 0.4);
+  color: var(--accent-strong);
+  padding-block: 0.5rem;
+}
+
+button.ghost:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.expedition-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.mission-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.stat {
+  background: rgba(13, 16, 24, 0.75);
+  border-radius: 16px;
+  padding: 0.75rem 1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.stat .label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.stat .value {
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.map-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 720px) {
+  .map-wrapper {
+    flex-direction: row;
+  }
+}
+
+.map {
+  display: grid;
+  grid-template-columns: repeat(10, minmax(0, 1fr));
+  gap: 4px;
+  width: min(100%, 480px);
+  aspect-ratio: 1 / 1;
+  background: rgba(9, 11, 18, 0.85);
+  border-radius: 18px;
+  padding: 0.75rem;
+  border: 1px solid rgba(125, 166, 255, 0.25);
+}
+
+.tile {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.viewport {
-  display: grid;
-  gap: 1.5rem;
-  align-items: center;
-  justify-items: center;
-  padding: 3rem clamp(1rem, 4vw, 4rem);
-  background: radial-gradient(circle at top, #1f2533 0%, #0d0f14 70%);
-  border-radius: 24px;
-  box-shadow: 0 20px 60px rgba(5, 8, 15, 0.6);
-}
-
-.hud {
+  font-size: clamp(0.7rem, 2.2vw, 0.85rem);
   text-align: center;
+  padding: 0.2rem;
+  color: rgba(4, 6, 11, 0.9);
+  transition: transform 120ms ease;
 }
 
-.hud h1 {
-  margin: 0 0 0.5rem;
-  font-size: clamp(1.75rem, 4vw, 2.75rem);
+.tile[data-state="hidden"] {
+  background: rgba(18, 21, 32, 0.65);
+  color: transparent;
 }
 
-.hud .tagline {
+.tile[data-state="revealed"] {
+  border-color: rgba(255, 255, 255, 0.05);
+}
+
+.tile[data-state="current"] {
+  transform: scale(1.08);
+  box-shadow: 0 8px 20px rgba(84, 121, 255, 0.4);
+  border-color: rgba(125, 166, 255, 0.6);
+}
+
+.tile[data-resource="none"]::after {
+  content: "";
+}
+
+.tile[data-resource="iron"]::after,
+.tile[data-resource="crystal"]::after,
+.tile[data-resource="bio"]::after {
+  content: "•";
+  font-size: 1.2em;
+  margin-left: 0.25rem;
+  color: rgba(5, 7, 12, 0.7);
+}
+
+.tile[data-resource="iron"] {
+  background: linear-gradient(135deg, #9aa5b9, #d3dae6);
+}
+
+.tile[data-resource="crystal"] {
+  background: linear-gradient(135deg, #a371ff, #d0b8ff);
+}
+
+.tile[data-resource="bio"] {
+  background: linear-gradient(135deg, #76c98c, #c2ffd7);
+}
+
+.tile[data-biome="plain"][data-resource="none"] {
+  background: linear-gradient(135deg, #6e8fff, #b0c8ff);
+}
+
+.tile[data-biome="mountain"][data-resource="none"] {
+  background: linear-gradient(135deg, #5c647f, #8a96b6);
+}
+
+.tile[data-biome="jungle"][data-resource="none"] {
+  background: linear-gradient(135deg, #4d7a59, #7eb789);
+}
+
+.tile[data-biome="desert"][data-resource="none"] {
+  background: linear-gradient(135deg, #d6b267, #f2e3b0);
+}
+
+.tile[data-biome="tundra"][data-resource="none"] {
+  background: linear-gradient(135deg, #7f9bb7, #c3d9ef);
+}
+
+.tile[data-biome="swamp"][data-resource="none"] {
+  background: linear-gradient(135deg, #556f58, #8da78c);
+}
+
+.tile[data-biome="lava"][data-resource="none"] {
+  background: linear-gradient(135deg, #aa302f, #f5654b);
+}
+
+.tile[data-biome="ocean"][data-resource="none"] {
+  background: linear-gradient(135deg, #37598d, #5f8ddf);
+}
+
+.tile[data-biome="river"][data-resource="none"] {
+  background: linear-gradient(135deg, #4a7fb3, #8fceff);
+}
+
+.legend {
   margin: 0;
-  font-size: clamp(1rem, 2.5vw, 1.25rem);
-  color: #9aa7ff;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: var(--muted);
 }
 
-#gameCanvas {
-  width: min(90vw, 640px);
-  height: auto;
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dpad {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: repeat(3, auto);
+  justify-items: center;
+  gap: 0.35rem;
+}
+
+.dpad button {
+  width: 4rem;
+  height: 4rem;
   border-radius: 16px;
-  border: 2px solid rgba(154, 167, 255, 0.4);
-  background: linear-gradient(135deg, rgba(42, 53, 87, 0.8), rgba(15, 19, 33, 0.8));
+  font-size: 1.5rem;
+  background: rgba(125, 166, 255, 0.2);
+}
+
+.dpad .middle-row {
+  display: grid;
+  grid-template-columns: repeat(3, 4rem);
+  gap: 0.35rem;
+}
+
+.status-message {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+@media (max-width: 540px) {
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .dpad {
+    align-self: center;
+  }
+
+  .dpad button {
+    width: 3.5rem;
+    height: 3.5rem;
+    font-size: 1.35rem;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the landing page with a mobile-friendly UI for configuring worlds and rover loadouts
- add responsive styling, touch controls, and a map layout tailored to handheld screens
- implement procedural world generation, rover stats, energy management, and resource collection gameplay

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69105137ccf883308bb785e9e73d31fe)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the canvas prototype with a mobile-first Rover Explorer app featuring procedural 10×10 world gen, rover module loadouts, d‑pad controls, and resource collection with mission stats.
> 
> - **UI/UX (index.html, style.css)**
>   - Mobile-first layout with header/footer and three panels: `World Configuration`, `Rover Configuration`, and `Expedition Status`.
>   - Sliders for `age`, `temperature`, `humidity`; selects for `locomotion`, `power`, `cargo`, `utility`; `Launch`, `End`, and `Collect Resource` actions.
>   - 10×10 grid `map` with tiles, legend sidebar, on-screen d‑pad (up/left/scan/right/down), and status messages.
>   - Responsive, touch-optimized styling with visual states for tiles (hidden/revealed/current) and resource/biome theming; accessibility labels/ARIA.
> - **Gameplay/Logic (main.js)**
>   - Procedural world generation with biomes (`plain`, `mountain`, `desert`, `jungle`, `tundra`, `swamp`, `lava`, `ocean`, `river`) and resource placement (`iron`, `crystal`, `bio`).
>   - Rover modules affecting movement, energy, capacity, vision, and scans; movement costs by biome and locomotion; tile reveal radius and scanning.
>   - Actions: move, scan, collect; mission lifecycle: launch, update stats (`energy`, `cargo`, `resources`, `exploration`), and end mission.
> - **Cleanup**
>   - Removes previous canvas-based greeting prototype.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aca802328e8f2f3637d4c61027598a57bbc1461e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->