### PR TITLE
Revamp rover map with biomes, inspector, and testing tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
       <section class="panel" aria-labelledby="rover-config-title">
         <h2 id="rover-config-title">Rover Configuration</h2>
         <p class="panel-intro">Select modules that complement the mission's conditions.</p>
+        <p class="budget" aria-live="polite">Outfitting budget remaining: <span id="budgetValue">180</span> credits</p>
         <div class="form-field">
           <label for="locomotionSelect">Locomotion</label>
           <select id="locomotionSelect"></select>
@@ -80,28 +81,71 @@
             <span id="resourcesStat" class="value">0</span>
           </div>
           <div class="stat">
+            <span class="label">Credits</span>
+            <span id="creditsStat" class="value">0</span>
+          </div>
+          <div class="stat">
             <span class="label">Exploration</span>
             <span id="explorationStat" class="value">0</span>
           </div>
         </div>
         <div class="map-wrapper">
-          <div class="map" id="map" role="grid" aria-label="Exploration map"></div>
-          <aside class="map-sidebar">
-            <h3>Terrain Summary</h3>
-            <ul id="legend" class="legend"></ul>
-          </aside>
-        </div>
-        <div class="controls" aria-label="Rover controls">
-          <div class="dpad">
-            <button data-direction="up" aria-label="Move north">▲</button>
-            <div class="middle-row">
-              <button data-direction="left" aria-label="Move west">◄</button>
-              <button data-direction="scan" aria-label="Scan surroundings">◎</button>
-              <button data-direction="right" aria-label="Move east">►</button>
-            </div>
-            <button data-direction="down" aria-label="Move south">▼</button>
+          <div class="map-scroll" aria-label="Exploration map viewport">
+            <div class="map" id="map" role="grid" aria-label="Exploration map"></div>
           </div>
-          <button id="collectButton" class="primary" type="button">Collect Resource</button>
+          <aside class="map-sidebar">
+            <section class="legend-panel">
+              <h3>Terrain Legend</h3>
+              <ul id="legend" class="legend"></ul>
+            </section>
+            <section class="inspector" aria-live="polite">
+              <h3>Tile Intel</h3>
+              <p id="tileSummary">Tap a charted tile to inspect its biome and hazards.</p>
+              <dl class="tile-details">
+                <div>
+                  <dt>Biome</dt>
+                  <dd id="tileBiome">—</dd>
+                </div>
+                <div>
+                  <dt>Resource</dt>
+                  <dd id="tileResource">—</dd>
+                </div>
+                <div>
+                  <dt>Distance</dt>
+                  <dd id="tileDistance">—</dd>
+                </div>
+                <div>
+                  <dt>Move Cost</dt>
+                  <dd id="tileCost">—</dd>
+                </div>
+              </dl>
+              <button id="moveButton" class="ghost" type="button" disabled>Move Rover Here</button>
+            </section>
+            <section class="control-stack" aria-label="Rover controls">
+              <h3>Controls</h3>
+              <div class="controls">
+                <div class="dpad">
+                  <button data-direction="up" aria-label="Move north">▲</button>
+                  <div class="middle-row">
+                    <button data-direction="left" aria-label="Move west">◄</button>
+                    <button data-direction="scan" aria-label="Scan surroundings">◎</button>
+                    <button data-direction="right" aria-label="Move east">►</button>
+                  </div>
+                  <button data-direction="down" aria-label="Move south">▼</button>
+                </div>
+                <button id="collectButton" class="primary" type="button">Collect Resource</button>
+              </div>
+            </section>
+            <section class="testing" aria-label="Testing controls">
+              <h3>Mission Debug</h3>
+              <p class="hint">Grant resources or credits while prototyping.</p>
+              <div class="testing-buttons">
+                <button id="addResources" type="button">+50 Resources</button>
+                <button id="addCredits" type="button">+40 Credits</button>
+                <button id="refillEnergy" type="button">Refill Energy</button>
+              </div>
+            </section>
+          </aside>
         </div>
         <p class="status-message" id="statusMessage">Configure a mission and launch to begin your expedition.</p>
       </section>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
-const GRID_SIZE = 10;
+const GRID_SIZE = 100;
 const BASE_MOVE_COST = 4;
 const BASE_VISION = 1;
+const BASE_FUNDING = 180;
 
 const BIOME_LABELS = {
   plain: "Plain",
@@ -14,11 +15,42 @@ const BIOME_LABELS = {
   river: "River"
 };
 
+const BIOME_CODES = {
+  plain: "PL",
+  mountain: "MT",
+  desert: "DS",
+  jungle: "JG",
+  tundra: "TD",
+  swamp: "SW",
+  lava: "LV",
+  ocean: "OC",
+  river: "RV"
+};
+
+const BIOME_COLORS = {
+  plain: "#6e8fff",
+  mountain: "#5c647f",
+  desert: "#d6b267",
+  jungle: "#4d7a59",
+  tundra: "#7f9bb7",
+  swamp: "#556f58",
+  lava: "#aa302f",
+  ocean: "#37598d",
+  river: "#4a7fb3"
+};
+
 const RESOURCE_VALUES = {
   none: 0,
   iron: 12,
   crystal: 18,
   bio: 9
+};
+
+const RESOURCE_LABELS = {
+  none: "None detected",
+  iron: "Iron ore",
+  crystal: "Crystalline deposits",
+  bio: "Organic samples"
 };
 
 const locomotionModules = [
@@ -27,6 +59,7 @@ const locomotionModules = [
     name: "All-Terrain Wheels",
     description: "Balanced movers. Efficient on plains and dunes but slowed in deep jungle and swamps.",
     baseMultiplier: 1,
+    cost: 0,
     modifiers: {
       jungle: 1.2,
       swamp: 1.25,
@@ -40,6 +73,7 @@ const locomotionModules = [
     name: "Larva Treads",
     description: "Heavy treads shrug off rough or icy ground at the cost of higher baseline energy use.",
     baseMultiplier: 1.2,
+    cost: 35,
     modifiers: {
       mountain: 0.85,
       tundra: 0.85,
@@ -53,6 +87,7 @@ const locomotionModules = [
     name: "Hydro Skimmer",
     description: "Hovercraft that glides over water and wetlands. Struggles in steep or rocky terrain.",
     baseMultiplier: 1.15,
+    cost: 45,
     modifiers: {
       swamp: 0.7,
       ocean: 0.65,
@@ -68,19 +103,22 @@ const powerModules = [
     id: "compact",
     name: "Compact Core",
     description: "Reliable power pack suited for short sorties.",
-    energy: 52
+    energy: 120,
+    cost: 0
   },
   {
     id: "expansion",
     name: "Expansion Cells",
     description: "Additional battery racks that extend the mission clock.",
-    energy: 70
+    energy: 165,
+    cost: 30
   },
   {
     id: "fusion",
     name: "Fusion Capsule",
     description: "Prototype power plant enabling long-range expeditions.",
-    energy: 88
+    energy: 210,
+    cost: 55
   }
 ];
 
@@ -89,19 +127,22 @@ const cargoModules = [
     id: "satchel",
     name: "Survey Satchel",
     description: "Lightweight container that fits a handful of samples.",
-    capacity: 5
+    capacity: 5,
+    cost: 0
   },
   {
     id: "bay",
     name: "Modular Cargo Bay",
     description: "Balanced hold for extended runs without overburdening the rover.",
-    capacity: 8
+    capacity: 8,
+    cost: 20
   },
   {
     id: "vault",
     name: "Cryo Vault",
     description: "Cryogenic vault for delicate resources. Heavy but cavernous.",
-    capacity: 11
+    capacity: 11,
+    cost: 45
   }
 ];
 
@@ -113,7 +154,8 @@ const utilityModules = [
     visionBonus: 0,
     scanRange: 0,
     scanCost: 0,
-    resourceBonus: 0
+    resourceBonus: 0,
+    cost: 0
   },
   {
     id: "scanner",
@@ -122,7 +164,8 @@ const utilityModules = [
     visionBonus: 1,
     scanRange: 2,
     scanCost: 6,
-    resourceBonus: 0
+    resourceBonus: 0,
+    cost: 25
   },
   {
     id: "excavator",
@@ -131,7 +174,8 @@ const utilityModules = [
     visionBonus: 0,
     scanRange: 1,
     scanCost: 5,
-    resourceBonus: 3
+    resourceBonus: 3,
+    cost: 30
   }
 ];
 
@@ -174,10 +218,23 @@ const collectButton = document.getElementById("collectButton");
 const statusMessage = document.getElementById("statusMessage");
 const endButton = document.getElementById("endButton");
 const controlButtons = Array.from(document.querySelectorAll(".dpad button"));
+const moveButton = document.getElementById("moveButton");
+const addResourcesButton = document.getElementById("addResources");
+const addCreditsButton = document.getElementById("addCredits");
+const refillEnergyButton = document.getElementById("refillEnergy");
+
+const tileSummary = document.getElementById("tileSummary");
+const tileBiome = document.getElementById("tileBiome");
+const tileResource = document.getElementById("tileResource");
+const tileDistance = document.getElementById("tileDistance");
+const tileCost = document.getElementById("tileCost");
+
+const budgetValue = document.getElementById("budgetValue");
 
 const energyStat = document.getElementById("energyStat");
 const cargoStat = document.getElementById("cargoStat");
 const resourcesStat = document.getElementById("resourcesStat");
+const creditsStat = document.getElementById("creditsStat");
 const explorationStat = document.getElementById("explorationStat");
 
 const state = {
@@ -191,6 +248,9 @@ const state = {
   cargoCapacity: 0,
   resources: 0,
   exploration: 0,
+  credits: BASE_FUNDING,
+  totalFunding: BASE_FUNDING,
+  inspectedTile: null,
   modules: {
     locomotion: locomotionModules[0],
     power: powerModules[0],
@@ -213,14 +273,18 @@ function initialise() {
     });
   });
 
-  populateSelect(selects.locomotion, locomotionModules, module => module.name, module => module.description);
-  populateSelect(selects.power, powerModules, module => module.name, module => module.description);
-  populateSelect(selects.cargo, cargoModules, module => module.name, module => module.description);
-  populateSelect(selects.utility, utilityModules, module => module.name, module => module.description);
+  populateSelect(selects.locomotion, locomotionModules);
+  populateSelect(selects.power, powerModules);
+  populateSelect(selects.cargo, cargoModules);
+  populateSelect(selects.utility, utilityModules);
 
   launchButton.addEventListener("click", launchExpedition);
   collectButton.addEventListener("click", collectResource);
   endButton.addEventListener("click", endExpedition);
+  moveButton.addEventListener("click", moveToInspectedTile);
+  addResourcesButton.addEventListener("click", () => grantResources(50));
+  addCreditsButton.addEventListener("click", () => grantCredits(40));
+  refillEnergyButton.addEventListener("click", refillMissionEnergy);
 
   controlButtons.forEach(button => {
     button.addEventListener("click", () => {
@@ -234,32 +298,151 @@ function initialise() {
   });
 
   updateUIStates(false);
-  updateStats();
+  syncCreditsWithLoadout();
+  updateInspector(null);
 }
 
-function populateSelect(selectElement, modules, labelGetter, descriptionGetter) {
+function populateSelect(selectElement, modules) {
+  const slot = selectElement.id.replace("Select", "");
   selectElement.innerHTML = "";
   modules.forEach(module => {
     const option = document.createElement("option");
     option.value = module.id;
-    option.textContent = labelGetter(module);
+    option.textContent = `${module.name} — ${module.cost}¢`;
     selectElement.append(option);
   });
 
-  selectElement.value = modules[0].id;
-  hints[selectElement.id.replace("Select", "")].textContent = descriptionGetter(modules[0]);
+  const defaultModule = modules[0];
+  selectElement.value = defaultModule.id;
+  state.modules[slot] = defaultModule;
+  updateModuleHint(slot, defaultModule);
 
   selectElement.addEventListener("change", () => {
     const selectedModule = modules.find(module => module.id === selectElement.value);
-    const hintKey = selectElement.id.replace("Select", "");
-    hints[hintKey].textContent = descriptionGetter(selectedModule);
-    state.modules[hintKey] = selectedModule;
+    handleModuleSelection(slot, selectedModule, selectElement);
   });
+}
 
-  state.modules[selectElement.id.replace("Select", "")] = modules[0];
+function updateModuleHint(slot, module) {
+  hints[slot].textContent = `${module.description} Cost: ${module.cost} credits.`;
+}
+
+function handleModuleSelection(slot, selectedModule, selectElement) {
+  const previousModule = state.modules[slot];
+  state.modules[slot] = selectedModule;
+  const spent = calculateLoadoutCost();
+  if (spent > state.totalFunding) {
+    state.modules[slot] = previousModule;
+    selectElement.value = previousModule.id;
+    updateModuleHint(slot, previousModule);
+    setStatus(`Budget exceeded by ${spent - state.totalFunding} credits. Add funding or choose a cheaper module.`);
+    return;
+  }
+  updateModuleHint(slot, selectedModule);
+  syncCreditsWithLoadout();
+}
+
+function calculateLoadoutCost() {
+  return Object.values(state.modules).reduce((total, module) => total + (module?.cost ?? 0), 0);
+}
+
+function syncCreditsWithLoadout() {
+  const remaining = Math.max(0, state.totalFunding - calculateLoadoutCost());
+  state.credits = remaining;
+  updateBudgetDisplay();
+  updateStats();
+}
+
+function updateBudgetDisplay() {
+  if (!budgetValue) return;
+  const remaining = Math.max(0, state.totalFunding - calculateLoadoutCost());
+  budgetValue.textContent = `${remaining}`;
+}
+
+function grantResources(amount) {
+  state.resources += amount;
+  updateStats();
+  setStatus(`Testing: granted ${amount} resource units.`);
+}
+
+function grantCredits(amount) {
+  state.totalFunding += amount;
+  syncCreditsWithLoadout();
+  setStatus(`Testing: outfitting budget increased by ${amount} credits.`);
+}
+
+function refillMissionEnergy() {
+  if (!state.running) {
+    setStatus("No active expedition. Launch to activate the rover before refilling energy.");
+    return;
+  }
+  state.energy = state.maxEnergy;
+  updateStats();
+  setStatus("Testing: rover energy fully replenished.");
+  inspectTile(getCurrentTile());
+}
+
+function moveToInspectedTile() {
+  if (!state.running || !state.inspectedTile) return;
+  const tile = state.inspectedTile;
+  const dx = tile.x - state.position.x;
+  const dy = tile.y - state.position.y;
+  if (Math.abs(dx) + Math.abs(dy) !== 1) {
+    setStatus("Select an adjacent tile to move the rover.");
+    return;
+  }
+  const direction = dx === 1 ? "right" : dx === -1 ? "left" : dy === 1 ? "down" : "up";
+  moveRover(direction);
+}
+
+function inspectTile(tile) {
+  state.inspectedTile = tile;
+  updateInspector(tile);
+}
+
+function updateInspector(tile) {
+  if (!tile) {
+    tileSummary.textContent = "Tap a charted tile to inspect its biome and hazards.";
+    tileBiome.textContent = "—";
+    tileResource.textContent = "—";
+    tileDistance.textContent = "—";
+    tileCost.textContent = "—";
+    moveButton.disabled = true;
+    updateTileStates();
+    return;
+  }
+
+  const discovered = tile.discovered;
+  const currentTile = state.running ? getCurrentTile() : null;
+  if (!discovered) {
+    tileSummary.textContent = "Sensors have not mapped this region yet.";
+    tileBiome.textContent = "Unknown";
+    tileResource.textContent = "Unknown";
+    tileDistance.textContent = `${Math.abs(tile.x - state.position.x) + Math.abs(tile.y - state.position.y)} tiles`;
+    tileCost.textContent = "?";
+    moveButton.disabled = true;
+  } else {
+    const distance = Math.abs(tile.x - state.position.x) + Math.abs(tile.y - state.position.y);
+    const cost = calculateMovementCost(tile);
+    tileSummary.textContent = tile === currentTile ? "Rover location." : "Projected traversal data ready.";
+    tileBiome.textContent = BIOME_LABELS[tile.biome] ?? tile.biome;
+    const resourceLabel = RESOURCE_LABELS[tile.resource] ?? tile.resource;
+    tileResource.textContent = resourceLabel;
+    tileDistance.textContent = `${distance} tile${distance === 1 ? "" : "s"}`;
+    tileCost.textContent = Number.isFinite(cost) ? `${cost} energy` : "Impassable";
+    const canMove = state.running && distance === 1 && Number.isFinite(cost) && state.energy >= cost;
+    moveButton.disabled = !canMove;
+  }
+
+  updateTileStates();
 }
 
 function launchExpedition() {
+  if (calculateLoadoutCost() > state.totalFunding) {
+    setStatus('Cannot launch while outfitting budget is exceeded.');
+    return;
+  }
+
   const age = Number(selectors.ageSlider.value);
   const temperature = Number(selectors.temperatureSlider.value);
   const humidity = Number(selectors.humiditySlider.value);
@@ -270,6 +453,7 @@ function launchExpedition() {
   state.modules.power = powerModules.find(module => module.id === selects.power.value);
   state.modules.cargo = cargoModules.find(module => module.id === selects.cargo.value);
   state.modules.utility = utilityModules.find(module => module.id === selects.utility.value);
+  syncCreditsWithLoadout();
 
   state.energy = state.modules.power.energy;
   state.maxEnergy = state.modules.power.energy;
@@ -284,10 +468,12 @@ function launchExpedition() {
   state.tiles = generation.tiles;
   state.world.legend = generation.legend;
   state.position = { x: Math.floor(GRID_SIZE / 2), y: Math.floor(GRID_SIZE / 2) };
+  state.inspectedTile = null;
 
   renderLegend(state.world.legend);
   buildMap();
   revealArea(state.position.x, state.position.y, BASE_VISION + state.modules.utility.visionBonus);
+  inspectTile(getCurrentTile());
   updateStats();
   updateUIStates(true);
   setStatus("Expedition launched. Chart the unknown and recover resources.");
@@ -310,11 +496,97 @@ function generateWorld(age, temperature, humidity) {
   const tiles = [];
   const legend = new Map();
   const seed = Math.floor(Date.now() + age * 31 + temperature * 97 + humidity * 131);
+  const ageNorm = age / 100;
+  const tempNorm = temperature / 100;
+  const humidityNorm = humidity / 100;
+
+  const elevationField = [];
+  const moistureField = [];
+  const temperatureField = [];
+
+  for (let y = 0; y < GRID_SIZE; y += 1) {
+    const elevationRow = [];
+    const moistureRow = [];
+    const temperatureRow = [];
+    const latitude = y / (GRID_SIZE - 1);
+    for (let x = 0; x < GRID_SIZE; x += 1) {
+      const reliefScale = 1.4 + (1 - ageNorm) * 1.1;
+      const elevationNoise = layeredNoise(x, y, reliefScale, seed);
+      const elevation = Math.pow(elevationNoise, 0.65 + ageNorm * 0.7);
+
+      const moistureNoise = layeredNoise(x + 13, y + 7, 1.45, seed * 0.7 + 113);
+      const equatorMoistureBias = 1 - Math.abs(latitude - 0.5) * 1.2;
+      const moisture = clamp(humidityNorm * 0.45 + moistureNoise * 0.55 + equatorMoistureBias * 0.08, 0, 1);
+
+      const tempNoise = layeredNoise(x + 3, y + 19, 0.95, seed * 1.1 + 37);
+      const polarBias = Math.abs(latitude - 0.5);
+      const temperatureValue = clamp(tempNorm * 0.5 + tempNoise * 0.45 + (1 - polarBias) * 0.12 - polarBias * 0.15, 0, 1);
+
+      elevationRow.push(elevation);
+      moistureRow.push(moisture);
+      temperatureRow.push(temperatureValue);
+    }
+    elevationField.push(elevationRow);
+    moistureField.push(moistureRow);
+    temperatureField.push(temperatureRow);
+  }
+
+  const seaLevel = 0.23 - ageNorm * 0.04 + (0.5 - humidityNorm) * 0.03;
+  const oceanMask = floodFillOceans(elevationField, seaLevel);
+  const ridgeField = buildRidgeField(elevationField, seed);
+
+  let biomeGrid = Array.from({ length: GRID_SIZE }, () => Array(GRID_SIZE).fill("plain"));
+
+  for (let y = 0; y < GRID_SIZE; y += 1) {
+    const latitude = y / (GRID_SIZE - 1);
+    for (let x = 0; x < GRID_SIZE; x += 1) {
+      const elevation = elevationField[y][x];
+      const moisture = moistureField[y][x];
+      const tempValue = temperatureField[y][x];
+      const nearOcean = hasOceanNeighbor(oceanMask, x, y);
+
+      let biome = "plain";
+      if (oceanMask[y][x]) {
+        biome = "ocean";
+      } else if (ridgeField[y][x] > 1.18) {
+        biome = "mountain";
+      } else if (elevation > 0.84 && tempValue > 0.6 && ageNorm < 0.45) {
+        biome = "lava";
+      } else if (elevation <= seaLevel + 0.02 && (nearOcean || moisture > 0.68)) {
+        biome = "river";
+      } else if (moisture > 0.75 && tempValue > 0.58) {
+        biome = "jungle";
+      } else if (moisture > 0.7 && (nearOcean || elevation < seaLevel + 0.08)) {
+        biome = "swamp";
+      } else if (tempValue < 0.3 || latitude < 0.12 || latitude > 0.88) {
+        biome = "tundra";
+      } else if (moisture < 0.28 && tempValue > 0.52) {
+        biome = "desert";
+      }
+
+      biomeGrid[y][x] = biome;
+    }
+  }
+
+  biomeGrid = smoothBiomes(biomeGrid, new Set(["ocean", "mountain", "lava"]));
+  carveRivers(biomeGrid, elevationField, moistureField, seaLevel, oceanMask);
+  spreadWetlands(biomeGrid, moistureField, oceanMask);
 
   for (let y = 0; y < GRID_SIZE; y += 1) {
     const row = [];
     for (let x = 0; x < GRID_SIZE; x += 1) {
-      const tile = createTile(x, y, age, temperature, humidity, seed);
+      const biome = oceanMask[y][x] ? "ocean" : biomeGrid[y][x];
+      const elevation = elevationField[y][x];
+      const moisture = moistureField[y][x];
+      const tempValue = temperatureField[y][x];
+      const tile = {
+        x,
+        y,
+        biome,
+        resource: determineResource(biome, moisture, elevation, tempValue, seed, x, y),
+        discovered: false,
+        element: null
+      };
       row.push(tile);
       tiles.push(tile);
       legend.set(tile.biome, (legend.get(tile.biome) ?? 0) + 1);
@@ -323,51 +595,6 @@ function generateWorld(age, temperature, humidity) {
   }
 
   return { grid, tiles, legend };
-}
-
-function createTile(x, y, age, temperature, humidity, seed) {
-  const ageNorm = age / 100;
-  const tempNorm = temperature / 100;
-  const humidityNorm = humidity / 100;
-  const reliefScale = 1.2 + (1 - ageNorm) * 1.3;
-  const elevationNoise = layeredNoise(x, y, reliefScale, seed);
-  const moistureNoise = layeredNoise(x + 13, y + 7, 1.4, seed * 0.7 + 113);
-  const tempNoise = layeredNoise(x + 3, y + 19, 0.9, seed * 1.1 + 37);
-
-  const elevation = Math.pow(elevationNoise, 0.65 + ageNorm * 0.8);
-  const moisture = Math.min(1, humidityNorm * 0.55 + moistureNoise * 0.7);
-  const tempValue = Math.min(1, tempNorm * 0.5 + tempNoise * 0.7);
-
-  let biome = "plain";
-
-  if (elevation < 0.18) {
-    biome = humidityNorm > 0.5 ? "river" : "ocean";
-  } else if (elevation > 0.82 && tempValue > 0.6 && ageNorm < 0.4) {
-    biome = "lava";
-  } else if (elevation > 0.72) {
-    biome = "mountain";
-  } else if (moisture > 0.7 && tempValue > 0.6) {
-    biome = "jungle";
-  } else if (moisture > 0.68) {
-    biome = "swamp";
-  } else if (tempValue < 0.28) {
-    biome = "tundra";
-  } else if (moisture < 0.28 && tempValue > 0.55) {
-    biome = "desert";
-  } else {
-    biome = "plain";
-  }
-
-  const resource = determineResource(biome, moisture, elevation, tempValue, seed, x, y);
-
-  return {
-    x,
-    y,
-    biome,
-    resource,
-    discovered: false,
-    element: null
-  };
 }
 
 function layeredNoise(x, y, scale, seed) {
@@ -410,9 +637,226 @@ function determineResource(biome, moisture, elevation, tempValue, seed, x, y) {
   return "none";
 }
 
+function floodFillOceans(elevationField, seaLevel) {
+  const mask = Array.from({ length: GRID_SIZE }, () => Array(GRID_SIZE).fill(false));
+  const visited = Array.from({ length: GRID_SIZE }, () => Array(GRID_SIZE).fill(false));
+  const queue = [];
+  let head = 0;
+  const threshold = seaLevel + 0.035;
+
+  for (let x = 0; x < GRID_SIZE; x += 1) {
+    if (!visited[0][x] && elevationField[0][x] <= seaLevel) {
+      queue.push({ x, y: 0 });
+      visited[0][x] = true;
+    }
+    if (!visited[GRID_SIZE - 1][x] && elevationField[GRID_SIZE - 1][x] <= seaLevel) {
+      queue.push({ x, y: GRID_SIZE - 1 });
+      visited[GRID_SIZE - 1][x] = true;
+    }
+  }
+
+  for (let y = 0; y < GRID_SIZE; y += 1) {
+    if (!visited[y][0] && elevationField[y][0] <= seaLevel) {
+      queue.push({ x: 0, y });
+      visited[y][0] = true;
+    }
+    if (!visited[y][GRID_SIZE - 1] && elevationField[y][GRID_SIZE - 1] <= seaLevel) {
+      queue.push({ x: GRID_SIZE - 1, y });
+      visited[y][GRID_SIZE - 1] = true;
+    }
+  }
+
+  const directions = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1]
+  ];
+
+  while (head < queue.length) {
+    const { x, y } = queue[head];
+    head += 1;
+    mask[y][x] = true;
+    directions.forEach(([dx, dy]) => {
+      const nx = x + dx;
+      const ny = y + dy;
+      if (nx < 0 || ny < 0 || nx >= GRID_SIZE || ny >= GRID_SIZE) {
+        return;
+      }
+      if (visited[ny][nx]) {
+        return;
+      }
+      if (elevationField[ny][nx] <= threshold) {
+        visited[ny][nx] = true;
+        queue.push({ x: nx, y: ny });
+      }
+    });
+  }
+
+  return mask;
+}
+
+function hasOceanNeighbor(oceanMask, x, y) {
+  for (let dy = -1; dy <= 1; dy += 1) {
+    for (let dx = -1; dx <= 1; dx += 1) {
+      if (dx === 0 && dy === 0) continue;
+      const nx = x + dx;
+      const ny = y + dy;
+      if (nx < 0 || ny < 0 || nx >= GRID_SIZE || ny >= GRID_SIZE) continue;
+      if (oceanMask[ny][nx]) return true;
+    }
+  }
+  return false;
+}
+
+function buildRidgeField(elevationField, seed) {
+  const ridgeField = [];
+  for (let y = 0; y < GRID_SIZE; y += 1) {
+    const row = [];
+    const latitude = y / (GRID_SIZE - 1);
+    const latBand = Math.exp(-Math.pow((latitude - 0.25) / 0.18, 2)) + Math.exp(-Math.pow((latitude - 0.75) / 0.2, 2));
+    for (let x = 0; x < GRID_SIZE; x += 1) {
+      const ridgeNoise = layeredNoise(x + 71, y + 91, 0.55, seed * 1.37 + 211);
+      const plateNoise = layeredNoise(x + 191, y + 17, 0.35, seed * 0.93 + 503);
+      const base = elevationField[y][x] * 1.1 + ridgeNoise * 0.3 + plateNoise * 0.2 + latBand * 0.35;
+      row.push(base);
+    }
+    ridgeField.push(row);
+  }
+  return ridgeField;
+}
+
+function smoothBiomes(grid, preserve) {
+  let working = grid.map(row => row.slice());
+  for (let iteration = 0; iteration < 2; iteration += 1) {
+    const snapshot = working.map(row => row.slice());
+    for (let y = 0; y < GRID_SIZE; y += 1) {
+      for (let x = 0; x < GRID_SIZE; x += 1) {
+        const current = snapshot[y][x];
+        if (preserve.has(current)) continue;
+        const counts = new Map();
+        for (let dy = -1; dy <= 1; dy += 1) {
+          for (let dx = -1; dx <= 1; dx += 1) {
+            const nx = x + dx;
+            const ny = y + dy;
+            if (nx < 0 || ny < 0 || nx >= GRID_SIZE || ny >= GRID_SIZE) continue;
+            const biome = snapshot[ny][nx];
+            counts.set(biome, (counts.get(biome) ?? 0) + 1);
+          }
+        }
+        let bestBiome = current;
+        let bestCount = counts.get(current) ?? 0;
+        counts.forEach((count, biome) => {
+          if (count > bestCount && !preserve.has(biome)) {
+            bestBiome = biome;
+            bestCount = count;
+          }
+        });
+        working[y][x] = bestBiome;
+      }
+    }
+  }
+  return working;
+}
+
+function carveRivers(biomeGrid, elevationField, moistureField, seaLevel, oceanMask) {
+  const candidates = [];
+  for (let y = 0; y < GRID_SIZE; y += 1) {
+    for (let x = 0; x < GRID_SIZE; x += 1) {
+      if (oceanMask[y][x]) continue;
+      const elevation = elevationField[y][x];
+      const moisture = moistureField[y][x];
+      if (elevation > seaLevel + 0.05 && moisture > 0.74) {
+        candidates.push({ x, y, score: moisture + elevation });
+      }
+    }
+  }
+
+  candidates.sort((a, b) => b.score - a.score);
+  const riverCount = Math.max(4, Math.floor(GRID_SIZE / 12));
+
+  const directions = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1]
+  ];
+
+  for (let i = 0; i < Math.min(riverCount, candidates.length); i += 1) {
+    let { x, y } = candidates[i];
+    const visited = new Set();
+    let steps = 0;
+    while (steps < GRID_SIZE * 3) {
+      const key = `${x},${y}`;
+      if (visited.has(key)) break;
+      visited.add(key);
+
+      if (!oceanMask[y][x] && biomeGrid[y][x] !== "mountain" && biomeGrid[y][x] !== "lava") {
+        biomeGrid[y][x] = "river";
+      }
+      if (oceanMask[y][x] || elevationField[y][x] <= seaLevel) {
+        break;
+      }
+
+      let next = null;
+      let lowest = elevationField[y][x];
+      directions.forEach(([dx, dy]) => {
+        const nx = x + dx;
+        const ny = y + dy;
+        if (nx < 0 || ny < 0 || nx >= GRID_SIZE || ny >= GRID_SIZE) return;
+        const neighborElevation = elevationField[ny][nx];
+        if (neighborElevation < lowest || oceanMask[ny][nx]) {
+          lowest = neighborElevation;
+          next = { x: nx, y: ny };
+        }
+      });
+
+      if (!next) {
+        break;
+      }
+      x = next.x;
+      y = next.y;
+      steps += 1;
+    }
+  }
+}
+
+function spreadWetlands(biomeGrid, moistureField, oceanMask) {
+  for (let y = 0; y < GRID_SIZE; y += 1) {
+    for (let x = 0; x < GRID_SIZE; x += 1) {
+      if (biomeGrid[y][x] !== "plain") continue;
+      if (moistureField[y][x] < 0.63) continue;
+      const nearWater = hasOceanNeighbor(oceanMask, x, y) || hasNeighborBiome(biomeGrid, x, y, "river");
+      if (nearWater) {
+        biomeGrid[y][x] = "swamp";
+      }
+    }
+  }
+}
+
+function hasNeighborBiome(grid, x, y, biome) {
+  for (let dy = -1; dy <= 1; dy += 1) {
+    for (let dx = -1; dx <= 1; dx += 1) {
+      if (dx === 0 && dy === 0) continue;
+      const nx = x + dx;
+      const ny = y + dy;
+      if (nx < 0 || ny < 0 || nx >= GRID_SIZE || ny >= GRID_SIZE) continue;
+      if (grid[ny][nx] === biome) return true;
+    }
+  }
+  return false;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
 function buildMap() {
   mapElement.innerHTML = "";
   const fragment = document.createDocumentFragment();
+  const tileSize = Math.max(6, Math.floor(520 / GRID_SIZE));
+  mapElement.style.setProperty("--grid-size", GRID_SIZE);
+  mapElement.style.setProperty("--tile-size", `${tileSize}px`);
   state.grid.forEach(row => {
     row.forEach(tile => {
       const tileElement = document.createElement("div");
@@ -420,6 +864,7 @@ function buildMap() {
       tileElement.dataset.state = "hidden";
       tileElement.dataset.biome = tile.biome;
       tileElement.dataset.resource = "none";
+      tileElement.dataset.inspected = "false";
       tileElement.textContent = "";
       tile.element = tileElement;
       tileElement.addEventListener("click", () => handleTileTap(tile));
@@ -431,12 +876,7 @@ function buildMap() {
 
 function handleTileTap(tile) {
   if (!state.running) return;
-  const dx = tile.x - state.position.x;
-  const dy = tile.y - state.position.y;
-  const isAdjacent = Math.abs(dx) + Math.abs(dy) === 1;
-  if (isAdjacent) {
-    moveRover(dx === 1 ? "right" : dx === -1 ? "left" : dy === 1 ? "down" : "up");
-  }
+  inspectTile(tile);
 }
 
 function revealArea(cx, cy, radius) {
@@ -456,21 +896,24 @@ function revealTile(x, y) {
     state.exploration += 1;
   }
   tile.element.dataset.state = "revealed";
-  tile.element.textContent = BIOME_LABELS[tile.biome];
+  tile.element.textContent = BIOME_CODES[tile.biome] ?? tile.biome.slice(0, 2).toUpperCase();
 }
 
 function updateTileStates() {
   state.grid.forEach(row => {
     row.forEach(tile => {
+      const isCurrent = state.running && tile === getCurrentTile();
+      const isInspected = state.inspectedTile === tile;
       if (!tile.discovered) {
         tile.element.dataset.state = "hidden";
         tile.element.textContent = "";
         tile.element.dataset.resource = "none";
       } else {
-        tile.element.textContent = BIOME_LABELS[tile.biome];
-        tile.element.dataset.state = tile === getCurrentTile() ? "current" : "revealed";
+        tile.element.textContent = BIOME_CODES[tile.biome] ?? tile.biome.slice(0, 2).toUpperCase();
+        tile.element.dataset.state = isCurrent ? "current" : "revealed";
         tile.element.dataset.resource = tile.resource;
       }
+      tile.element.dataset.inspected = isInspected ? "true" : "false";
     });
   });
 }
@@ -514,7 +957,7 @@ function moveRover(direction) {
   state.energy -= cost;
   state.position = { x: targetX, y: targetY };
   revealArea(targetX, targetY, BASE_VISION + state.modules.utility.visionBonus);
-  updateTileStates();
+  inspectTile(targetTile);
   updateStats();
   describeTile(targetTile);
 
@@ -557,6 +1000,7 @@ function performScan() {
   }
   state.energy -= scanCost;
   revealArea(state.position.x, state.position.y, scanRange + BASE_VISION);
+  inspectTile(state.inspectedTile ?? getCurrentTile());
   updateStats();
   setStatus("Survey scan complete. Nearby tiles charted.");
 }
@@ -578,7 +1022,7 @@ function collectResource() {
   state.resources += value;
   setStatus(`Sample secured. Cargo usage: ${state.cargo}/${state.cargoCapacity}.`);
   tile.resource = "none";
-  updateTileStates();
+  inspectTile(tile);
   updateStats();
 }
 
@@ -586,6 +1030,7 @@ function updateStats() {
   energyStat.textContent = `${state.energy} / ${state.maxEnergy}`;
   cargoStat.textContent = `${state.cargo} / ${state.cargoCapacity}`;
   resourcesStat.textContent = `${state.resources}`;
+  creditsStat.textContent = `${state.credits}`;
   explorationStat.textContent = `${state.exploration}`;
 }
 
@@ -595,10 +1040,15 @@ function setStatus(message) {
 
 function renderLegend(legend) {
   legendElement.innerHTML = "";
+  const totalTiles = GRID_SIZE * GRID_SIZE;
   const entries = Array.from(legend.entries()).sort((a, b) => b[1] - a[1]);
   entries.forEach(([biome, count]) => {
     const item = document.createElement("li");
-    item.textContent = `${BIOME_LABELS[biome] ?? biome}: ${count}`;
+    const percent = Math.round((count / totalTiles) * 1000) / 10;
+    item.style.color = BIOME_COLORS[biome] ?? "#9cc4ff";
+    const code = BIOME_CODES[biome] ?? biome.toUpperCase();
+    const label = BIOME_LABELS[biome] ?? biome;
+    item.innerHTML = `<span class="legend-code">${code}</span> ${label} · ${count} tiles (${percent}%)`;
     legendElement.append(item);
   });
 }
@@ -609,6 +1059,7 @@ function endExpedition() {
   }
   state.running = false;
   updateUIStates(false);
+  updateInspector(null);
   setStatus(`Mission concluded. Recovered resources valued at ${state.resources} units.`);
 }
 
@@ -618,6 +1069,7 @@ function updateUIStates(isRunning) {
   });
   collectButton.disabled = !isRunning;
   endButton.disabled = !isRunning;
+  moveButton.disabled = !isRunning;
   launchButton.disabled = false;
 }
 

--- a/style.css
+++ b/style.css
@@ -8,6 +8,8 @@
   --accent-strong: #9cc4ff;
   --text: #f4f6ff;
   --muted: #97a1c1;
+  --grid-size: 10;
+  --tile-size: 36px;
   background: radial-gradient(circle at 20% 20%, rgba(47, 61, 96, 0.45), transparent 60%),
     radial-gradient(circle at 80% 0%, rgba(37, 45, 71, 0.55), transparent 60%),
     var(--bg);
@@ -95,6 +97,12 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+}
+
+.budget {
+  margin: 0.25rem 0 0.5rem;
+  font-weight: 600;
+  color: var(--accent-strong);
 }
 
 .form-field label {
@@ -214,22 +222,29 @@ button.ghost:disabled {
   gap: 1rem;
 }
 
-@media (min-width: 720px) {
+@media (min-width: 860px) {
   .map-wrapper {
     flex-direction: row;
+    align-items: flex-start;
   }
 }
 
-.map {
-  display: grid;
-  grid-template-columns: repeat(10, minmax(0, 1fr));
-  gap: 4px;
-  width: min(100%, 480px);
-  aspect-ratio: 1 / 1;
+.map-scroll {
   background: rgba(9, 11, 18, 0.85);
   border-radius: 18px;
   padding: 0.75rem;
   border: 1px solid rgba(125, 166, 255, 0.25);
+  overflow: auto;
+  max-height: min(70vh, 620px);
+  max-width: min(100%, 520px);
+}
+
+.map {
+  display: grid;
+  grid-template-columns: repeat(var(--grid-size), var(--tile-size));
+  grid-auto-rows: var(--tile-size);
+  gap: 2px;
+  width: max-content;
 }
 
 .tile {
@@ -238,11 +253,15 @@ button.ghost:disabled {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: clamp(0.7rem, 2.2vw, 0.85rem);
+  font-size: clamp(0.55rem, 1.5vw, 0.7rem);
   text-align: center;
-  padding: 0.2rem;
+  padding: 0.15rem;
+  min-width: var(--tile-size);
+  min-height: var(--tile-size);
   color: rgba(4, 6, 11, 0.9);
   transition: transform 120ms ease;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .tile[data-state="hidden"] {
@@ -258,6 +277,11 @@ button.ghost:disabled {
   transform: scale(1.08);
   box-shadow: 0 8px 20px rgba(84, 121, 255, 0.4);
   border-color: rgba(125, 166, 255, 0.6);
+}
+
+.tile[data-inspected="true"] {
+  outline: 2px solid rgba(255, 255, 255, 0.55);
+  outline-offset: -2px;
 }
 
 .tile[data-resource="none"]::after {
@@ -330,12 +354,84 @@ button.ghost:disabled {
   color: var(--muted);
 }
 
+.legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.legend li::before {
+  content: "";
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 4px;
+  background: currentColor;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.legend-code {
+  font-weight: 700;
+  color: var(--text);
+}
+
+.map-sidebar {
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+  width: min(320px, 100%);
+}
+
+.legend-panel,
+.inspector,
+.control-stack,
+.testing {
+  background: rgba(13, 16, 24, 0.75);
+  border-radius: 16px;
+  padding: 0.85rem 1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.tile-details {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.tile-details div {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+}
+
+.tile-details dt {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.tile-details dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--accent-strong);
+}
+
 .controls {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
   align-items: center;
   justify-content: space-between;
+}
+
+.control-stack .controls {
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 0.75rem;
+}
+
+.control-stack .dpad {
+  align-self: center;
 }
 
 .dpad {
@@ -364,6 +460,17 @@ button.ghost:disabled {
   margin: 0;
   font-size: 0.95rem;
   color: var(--muted);
+}
+
+.testing-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.testing-buttons button {
+  flex: 1 1 120px;
+  background: rgba(125, 166, 255, 0.18);
 }
 
 @media (max-width: 540px) {


### PR DESCRIPTION
## Summary
- expand the map to a 100x100 grid and overhaul world generation with biome belts, contiguous oceans, rivers, and wetlands for more coherent terrain
- add module costs, outfitting budget tracking, credits stat visibility, and testing utilities to grant resources, funding, or energy while iterating
- redesign the expedition UI with a sidebar legend, tile inspector, consolidated controls, and updated styling so the board and controls share a single view

## Testing
- Not run (web UI change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691054ca18d88330ad1c713c2d64a8e7)